### PR TITLE
NGSTACK-665 add photoswipe, remove jquery and MFP

### DIFF
--- a/bundle/Resources/es6/app-full.js
+++ b/bundle/Resources/es6/app-full.js
@@ -1,3 +1,2 @@
 import '../sass/vendors.scss';
-import './vendors';
 import './app';

--- a/bundle/Resources/es6/app-full.js
+++ b/bundle/Resources/es6/app-full.js
@@ -1,2 +1,3 @@
 import '../sass/vendors.scss';
+import './vendors';
 import './app';

--- a/bundle/Resources/es6/gallery-blocks.js
+++ b/bundle/Resources/es6/gallery-blocks.js
@@ -1,6 +1,4 @@
-import Swiper from 'swiper';
-import PhotoSwipe from 'photoswipe';
-import PhotoSwipeLightbox from 'photoswipe/dist/photoswipe-lightbox.esm';
+/* global Swiper, PhotoSwipe, PhotoSwipeLightbox */
 
 window.addEventListener('load', () => {
   document.querySelectorAll('.ngl-vt-grid_gallery .js-lightbox-enabled').forEach((element) => {

--- a/bundle/Resources/es6/gallery-blocks.js
+++ b/bundle/Resources/es6/gallery-blocks.js
@@ -1,21 +1,15 @@
-/* global $, Swiper */
+import Swiper from 'swiper';
+import PhotoSwipe from 'photoswipe';
+import PhotoSwipeLightbox from 'photoswipe/dist/photoswipe-lightbox.esm';
 
 window.addEventListener('load', () => {
-  $('.nglayouts-as-flex').each((i, el) => {
-    if (!$(el).find('> *').length) $(el).remove();
-  });
-
-  $('.ngl-vt-grid_gallery .js-lightbox-enabled').each((i, el) => {
-    $(el).magnificPopup({
-      delegate: '.js-mfp-item', // child items selector, by clicking on it popup will open
-      type: 'image',
-      zoom: {
-        enabled: true,
-      },
-      gallery: {
-        enabled: true,
-      },
+  document.querySelectorAll('.ngl-vt-grid_gallery .js-lightbox-enabled').forEach((element) => {
+    const lightbox = new PhotoSwipeLightbox({
+      gallery: element,
+      children: '.js-lightbox-item',
+      pswpModule: PhotoSwipe,
     });
+    lightbox.init();
   });
 
   // Sushi swiper

--- a/bundle/Resources/es6/vendors.js
+++ b/bundle/Resources/es6/vendors.js
@@ -1,0 +1,7 @@
+import Swiper from 'swiper';
+import PhotoSwipe from 'photoswipe';
+import PhotoSwipeLightbox from 'photoswipe/dist/photoswipe-lightbox.esm';
+
+global.Swiper = Swiper;
+global.PhotoSwipe = PhotoSwipe;
+global.PhotoSwipeLightbox = PhotoSwipeLightbox;

--- a/bundle/Resources/es6/vendors.js
+++ b/bundle/Resources/es6/vendors.js
@@ -1,6 +1,0 @@
-import $ from 'jquery';
-import 'magnific-popup';
-import Swiper from 'swiper';
-
-global.$ = global.jQuery = $; // eslint-disable-line no-multi-assign
-global.Swiper = Swiper;

--- a/bundle/Resources/sass/vendors.scss
+++ b/bundle/Resources/sass/vendors.scss
@@ -1,2 +1,2 @@
 @import '../../../node_modules/swiper/dist/css/swiper';
-@import '../../../node_modules/magnific-popup/src/css/main';
+@import '../../../node_modules/photoswipe/dist/photoswipe.css';

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
         "webpack-cli": "^3.3.10"
     },
     "dependencies": {
-        "jquery": "^3.4.1",
-        "magnific-popup": "^1.1.0",
+        "photoswipe": "^5.3.4",
         "swiper": "^4.5.1"
     },
     "scripts": {


### PR DESCRIPTION
accidentally named branch after fslightbox, an old choice of library

Changes
---------
- dependency changes
  - added photoswipe
  - removed jquery and magnific-popup
- replaced MFP with photoswipe in js and css
- removed some code that clears empty nglayouts-as-flex elements - unnecessary (LJJ)
- commit about fixing vendors - belated realisation how it's supposed to work (app vs app-full)

Testing
-------
- build runs
- using app-full on a site without overrides should work (can comment out galleryblock and swiper components on bold site)